### PR TITLE
Connect frontend and backend authentication with MongoDB

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,0 +1,3 @@
+MONGO_URI=mongodb://localhost:27017/cdnc
+JWT_SECRET=changeme
+PORT=5001

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,3 +1,4 @@
 MONGO_URI=mongodb://localhost:27017/cdnc
+MP_MONGO_URI=mongodb://localhost:27017/MPContacts
 JWT_SECRET=changeme
 PORT=5001

--- a/Backend/Data/MPContact.js
+++ b/Backend/Data/MPContact.js
@@ -7,7 +7,10 @@ const mpContactSchema = new mongoose.Schema({
   email: String,
   phone: String,
   image: String,
+  // Some datasets store the province under "Province / Territory". Include
+  // both keys so queries work regardless of which field name is present.
   province: String,
+  "Province / Territory": String,
 });
 
 // Reuse the main connection string if a dedicated MP one isn't provided

--- a/Backend/Data/MPContact.js
+++ b/Backend/Data/MPContact.js
@@ -9,6 +9,12 @@ const mpContactSchema = new mongoose.Schema({
   image: String,
 });
 
-const mpConnection = mongoose.createConnection(process.env.MP_MONGO_URI);
+// Reuse the main connection string if a dedicated MP one isn't provided
+const mpUri = process.env.MP_MONGO_URI || process.env.MONGO_URI;
+
+const mpConnection = mongoose.createConnection(mpUri, {
+  dbName: process.env.MP_DB_NAME || "MPContacts",
+});
 
 module.exports = mpConnection.model("MPContact", mpContactSchema);
+

--- a/Backend/Data/MPContact.js
+++ b/Backend/Data/MPContact.js
@@ -1,0 +1,14 @@
+const mongoose = require("mongoose");
+
+const mpContactSchema = new mongoose.Schema({
+  name: String,
+  party: String,
+  constituency: String,
+  email: String,
+  phone: String,
+  image: String,
+});
+
+const mpConnection = mongoose.createConnection(process.env.MP_MONGO_URI);
+
+module.exports = mpConnection.model("MPContact", mpContactSchema);

--- a/Backend/Data/MPContact.js
+++ b/Backend/Data/MPContact.js
@@ -7,6 +7,7 @@ const mpContactSchema = new mongoose.Schema({
   email: String,
   phone: String,
   image: String,
+  province: String,
 });
 
 // Reuse the main connection string if a dedicated MP one isn't provided

--- a/Backend/Data/MPContact.js
+++ b/Backend/Data/MPContact.js
@@ -1,17 +1,16 @@
 const mongoose = require("mongoose");
 
-const mpContactSchema = new mongoose.Schema({
-  name: String,
-  party: String,
-  constituency: String,
-  email: String,
-  phone: String,
-  image: String,
-  // Some datasets store the province under "Province / Territory". Include
-  // both keys so queries work regardless of which field name is present.
-  province: String,
-  "Province / Territory": String,
-});
+const mpContactSchema = new mongoose.Schema(
+  {
+    "First Name": String,
+    "Last Name": String,
+    Constituency: String,
+    "Province / Territory": String,
+    "Political Affiliation": String,
+    "Start Date": String,
+  },
+  { strict: false }
+);
 
 // Reuse the main connection string if a dedicated MP one isn't provided
 const mpUri = process.env.MP_MONGO_URI || process.env.MONGO_URI;
@@ -21,4 +20,3 @@ const mpConnection = mongoose.createConnection(mpUri, {
 });
 
 module.exports = mpConnection.model("MPContact", mpContactSchema);
-

--- a/Backend/Data/User.js
+++ b/Backend/Data/User.js
@@ -2,7 +2,7 @@
 const mongoose = require("mongoose");
 
 const userSchema = new mongoose.Schema({
-  username: { type: String, required: true, unique: true },
+  email: { type: String, required: true, unique: true },
   passwordHash: { type: String, required: true },
   role: { type: String, enum: ["Host", "Player"], required: true },
   createdAt: { type: Date, default: Date.now },

--- a/Backend/Data/User.js
+++ b/Backend/Data/User.js
@@ -2,9 +2,13 @@
 const mongoose = require("mongoose");
 
 const userSchema = new mongoose.Schema({
+  fullName: { type: String, required: true },
   email: { type: String, required: true, unique: true },
+  city: { type: String },
+  province: { type: String },
+  zipCode: { type: String },
+  description: { type: String },
   passwordHash: { type: String, required: true },
-  role: { type: String, enum: ["Host", "Player"], required: true },
   createdAt: { type: Date, default: Date.now },
 });
 

--- a/Backend/controller/auth.controller.js
+++ b/Backend/controller/auth.controller.js
@@ -6,12 +6,12 @@ const { generateToken } = require('../utils/jwt');
 const register = async (req, res) => {
   console.log("✅ REGISTER route hit", req.body);
   try {
-    const { username, password, role } = req.body;
-    if (!username || !password || !role) {
+    const { email, password, role } = req.body;
+    if (!email || !password || !role) {
       return res.status(400).json({ error: "Missing fields" });
     }
     const passwordHash = await bcrypt.hash(password, 10);
-    const newUser = new User({ username, passwordHash, role });
+    const newUser = new User({ email, passwordHash, role });
     const result = await newUser.save();
     console.log("✅ Saved to DB:", result);
     res.status(201).json({ message: "User created" });
@@ -23,15 +23,15 @@ const register = async (req, res) => {
 
 const login = async (req, res) => {
   try {
-    const { username, password } = req.body;
+    const { email, password } = req.body;
 
-    const user = await User.findOne({ username });
+    const user = await User.findOne({ email });
     if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
 
     const token = generateToken(user);
-    res.status(200).json({ token, role: user.role, username: user.username });
+    res.status(200).json({ token, role: user.role, email: user.email });
   } catch (err) {
     console.error('❌ Login error:', err);
     res.status(500).json({ message: 'Server error during login' });

--- a/Backend/controller/auth.controller.js
+++ b/Backend/controller/auth.controller.js
@@ -3,39 +3,62 @@ const bcrypt = require("bcryptjs");
 const { generateToken } = require('../utils/jwt');
 
 // ✅ DEFINE REGISTER FIRST
-const register = async (req, res) => {
-  try {
-    const { fullName, email, city, province, zipCode, description, password } = req.body;
-    if (!fullName || !email || !password) {
-      return res.status(400).json({ error: "Missing required fields" });
+  const register = async (req, res) => {
+    try {
+      const { fullName, email, city, province, zipCode, description, password } = req.body;
+      if (!fullName || !email || !password) {
+        return res
+          .status(400)
+          .json({ error: "fullName, email and password are required" });
+      }
+
+      // Avoid duplicate accounts
+      const existing = await User.findOne({ email });
+      if (existing) {
+        return res.status(409).json({ error: "Email already registered" });
+      }
+
+      const passwordHash = await bcrypt.hash(password, 10);
+      const newUser = new User({
+        fullName,
+        email,
+        city,
+        province,
+        zipCode,
+        description,
+        passwordHash,
+      });
+      await newUser.save();
+      return res.status(201).json({ message: "User created" });
+    } catch (err) {
+      console.error("❌ Error:", err);
+      if (err.code === 11000) {
+        return res.status(409).json({ error: "Email already registered" });
+      }
+      return res.status(500).json({ error: "Failed to register user" });
     }
+  };
 
-    const passwordHash = await bcrypt.hash(password, 10);
-    const newUser = new User({ fullName, email, city, province, zipCode, description, passwordHash });
-    await newUser.save();
-    res.status(201).json({ message: "User created" });
-  } catch (err) {
-    console.error("❌ Error:", err);
-    res.status(500).json({ error: "Failed to register user" });
-  }
-};
+  const login = async (req, res) => {
+    try {
+      const { email, password } = req.body;
+      if (!email || !password) {
+        return res.status(400).json({ error: "Email and password required" });
+      }
 
-const login = async (req, res) => {
-  try {
-    const { email, password } = req.body;
+      const user = await User.findOne({ email });
+      const passwordValid = user && (await bcrypt.compare(password, user.passwordHash));
+      if (!passwordValid) {
+        return res.status(401).json({ error: "Invalid email or password" });
+      }
 
-    const user = await User.findOne({ email });
-    if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
-      return res.status(401).json({ message: 'Invalid credentials' });
+      const token = generateToken(user);
+      return res.status(200).json({ token, email: user.email });
+    } catch (err) {
+      console.error('❌ Login error:', err);
+      return res.status(500).json({ error: 'Server error during login' });
     }
-
-    const token = generateToken(user);
-    res.status(200).json({ token, email: user.email });
-  } catch (err) {
-    console.error('❌ Login error:', err);
-    res.status(500).json({ message: 'Server error during login' });
-  }
-};
+  };
 
 // ✅ THEN EXPORT IT
 module.exports = {

--- a/Backend/controller/auth.controller.js
+++ b/Backend/controller/auth.controller.js
@@ -4,16 +4,15 @@ const { generateToken } = require('../utils/jwt');
 
 // ✅ DEFINE REGISTER FIRST
 const register = async (req, res) => {
-  console.log("✅ REGISTER route hit", req.body);
   try {
-    const { email, password, role } = req.body;
-    if (!email || !password || !role) {
-      return res.status(400).json({ error: "Missing fields" });
+    const { fullName, email, city, province, zipCode, description, password } = req.body;
+    if (!fullName || !email || !password) {
+      return res.status(400).json({ error: "Missing required fields" });
     }
+
     const passwordHash = await bcrypt.hash(password, 10);
-    const newUser = new User({ email, passwordHash, role });
-    const result = await newUser.save();
-    console.log("✅ Saved to DB:", result);
+    const newUser = new User({ fullName, email, city, province, zipCode, description, passwordHash });
+    await newUser.save();
     res.status(201).json({ message: "User created" });
   } catch (err) {
     console.error("❌ Error:", err);
@@ -31,7 +30,7 @@ const login = async (req, res) => {
     }
 
     const token = generateToken(user);
-    res.status(200).json({ token, role: user.role, email: user.email });
+    res.status(200).json({ token, email: user.email });
   } catch (err) {
     console.error('❌ Login error:', err);
     res.status(500).json({ message: 'Server error during login' });

--- a/Backend/controller/mp.controller.js
+++ b/Backend/controller/mp.controller.js
@@ -11,7 +11,15 @@ const list = async (req, res) => {
           ],
         }
       : {};
-    const contacts = await MPContact.find(filter);
+    const raw = await MPContact.find(filter).lean();
+    const contacts = raw.map((c) => ({
+      id: c._id,
+      name: [c["First Name"], c["Last Name"]].filter(Boolean).join(" "),
+      party: c["Political Affiliation"],
+      constituency: c["Constituency"],
+      province: c["Province / Territory"] || c.province,
+      startDate: c["Start Date"],
+    }));
     return res.json(contacts);
   } catch (err) {
     console.error("❌ MP fetch error:", err);

--- a/Backend/controller/mp.controller.js
+++ b/Backend/controller/mp.controller.js
@@ -2,7 +2,11 @@ const MPContact = require("../Data/MPContact");
 
 const list = async (req, res) => {
   try {
-    const contacts = await MPContact.find();
+    const { province } = req.query;
+    const filter = province
+      ? { province: new RegExp(`^${province}$`, "i") }
+      : {};
+    const contacts = await MPContact.find(filter);
     return res.json(contacts);
   } catch (err) {
     console.error("❌ MP fetch error:", err);

--- a/Backend/controller/mp.controller.js
+++ b/Backend/controller/mp.controller.js
@@ -4,7 +4,12 @@ const list = async (req, res) => {
   try {
     const { province } = req.query;
     const filter = province
-      ? { province: new RegExp(`^${province}$`, "i") }
+      ? {
+          $or: [
+            { province: new RegExp(province, "i") },
+            { "Province / Territory": new RegExp(province, "i") },
+          ],
+        }
       : {};
     const contacts = await MPContact.find(filter);
     return res.json(contacts);

--- a/Backend/controller/mp.controller.js
+++ b/Backend/controller/mp.controller.js
@@ -1,0 +1,13 @@
+const MPContact = require("../Data/MPContact");
+
+const list = async (req, res) => {
+  try {
+    const contacts = await MPContact.find();
+    return res.json(contacts);
+  } catch (err) {
+    console.error("❌ MP fetch error:", err);
+    return res.status(500).json({ error: "Failed to fetch MP contacts" });
+  }
+};
+
+module.exports = { list };

--- a/Backend/routes/mp.routes.js
+++ b/Backend/routes/mp.routes.js
@@ -1,0 +1,6 @@
+const router = require("express").Router();
+const { list } = require("../controller/mp.controller");
+
+router.get("/", list);
+
+module.exports = router;

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -5,6 +5,7 @@ const dotenv = require("dotenv");
 const http = require("http");
 
 const authRoutes = require("./routes/auth.routes");
+const User = require("./Data/User");
 
 dotenv.config();
 
@@ -21,15 +22,17 @@ app.use(express.json());
 app.use("/api/auth", authRoutes);
 
 // MongoDB
-mongoose.connect(process.env.MONGO_URI)
-  .then(() => {
+mongoose
+  .connect(process.env.MONGO_URI)
+  .then(async () => {
     console.log("✅ MongoDB connected");
+    // Ensure obsolete indexes (e.g., legacy username) are removed
+    await User.syncIndexes();
 
     const PORT = process.env.PORT || 5001;
     server.listen(PORT, () => {
       console.log(`🚀 Server running at http://localhost:${PORT}`);
-    
     });
   })
-  .catch(err => console.error("❌ Mongo error:", err));
+  .catch((err) => console.error("❌ Mongo error:", err));
 

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -4,10 +4,11 @@ const cors = require("cors");
 const dotenv = require("dotenv");
 const http = require("http");
 
-const authRoutes = require("./routes/auth.routes");
-const User = require("./Data/User");
-
 dotenv.config();
+
+const authRoutes = require("./routes/auth.routes");
+const mpRoutes = require("./routes/mp.routes");
+const User = require("./Data/User");
 
 // App + Server
 const app = express();
@@ -20,6 +21,7 @@ app.use(express.json());
 
 // Routes
 app.use("/api/auth", authRoutes);
+app.use("/api/mps", mpRoutes);
 
 // MongoDB
 mongoose

--- a/Backend/utils/jwt.js
+++ b/Backend/utils/jwt.js
@@ -4,11 +4,11 @@ const SECRET = process.env.JWT_SECRET || 'secretkey';
 const generateToken = (user) => {
     const payload = {
       id: user._id,
-      username: user.username,
+      email: user.email,
       role: user.role,
     };
   
     return jwt.sign(payload, SECRET, { expiresIn: '2h' }); // same secret, same algorithm
   };
   
-  module.exports = { generateToken };
+module.exports = { generateToken };

--- a/Backend/utils/jwt.js
+++ b/Backend/utils/jwt.js
@@ -5,7 +5,6 @@ const generateToken = (user) => {
     const payload = {
       id: user._id,
       email: user.email,
-      role: user.role,
     };
   
     return jwt.sign(payload, SECRET, { expiresIn: '2h' }); // same secret, same algorithm

--- a/CDNC-frontend/package-lock.json
+++ b/CDNC-frontend/package-lock.json
@@ -83,7 +83,8 @@
         "tailwindcss": "^3.4.11",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
-        "vite": "^5.4.1"
+        "vite": "^5.4.1",
+        "vite-tsconfig-paths": "^5.1.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -5390,6 +5391,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7972,6 +7980,27 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
@@ -8266,6 +8295,26 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
           "optional": true
         }
       }

--- a/CDNC-frontend/package.json
+++ b/CDNC-frontend/package.json
@@ -86,6 +86,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/CDNC-frontend/src/App.tsx
+++ b/CDNC-frontend/src/App.tsx
@@ -9,6 +9,7 @@ import FindSupport from "./pages/FindSupport";
 import JoinCommunity from "./pages/JoinCommunity";
 import SendLetter from "./pages/SendLetter";
 import SignIn from "./pages/SignIn";
+import SignUp from "./pages/SignUp";
 import FindMP from "./pages/FindMP";
 import AdvocacyHub from "./pages/AdvocacyHub";
 import Resources from "./pages/Resources";
@@ -28,6 +29,7 @@ const App = () => (
           <Route path="/join-community" element={<JoinCommunity />} />
           <Route path="/send-letter" element={<SendLetter />} />
           <Route path="/sign-in" element={<SignIn />} />
+          <Route path="/sign-up" element={<SignUp />} />
           <Route path="/find-mp" element={<FindMP />} />
           <Route path="/advocacy" element={<AdvocacyHub />} />
           <Route path="/resources" element={<Resources />} />

--- a/CDNC-frontend/src/components/ui/command.tsx
+++ b/CDNC-frontend/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/CDNC-frontend/src/components/ui/textarea.tsx
+++ b/CDNC-frontend/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/CDNC-frontend/src/lib/api.ts
+++ b/CDNC-frontend/src/lib/api.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:5001/api";
+
+export const api = axios.create({
+  baseURL: API_BASE_URL,
+});
+
+export default api;

--- a/CDNC-frontend/src/lib/auth.ts
+++ b/CDNC-frontend/src/lib/auth.ts
@@ -1,0 +1,16 @@
+import api from "./api";
+
+export interface AuthResponse {
+  token: string;
+  role: string;
+  email: string;
+}
+
+export async function login(email: string, password: string): Promise<AuthResponse> {
+  const res = await api.post<AuthResponse>("/auth/login", { email, password });
+  return res.data;
+}
+
+export async function register(email: string, password: string, role: string): Promise<void> {
+  await api.post("/auth/register", { email, password, role });
+}

--- a/CDNC-frontend/src/lib/auth.ts
+++ b/CDNC-frontend/src/lib/auth.ts
@@ -2,7 +2,6 @@ import api from "./api";
 
 export interface AuthResponse {
   token: string;
-  role: string;
   email: string;
 }
 
@@ -11,6 +10,16 @@ export async function login(email: string, password: string): Promise<AuthRespon
   return res.data;
 }
 
-export async function register(email: string, password: string, role: string): Promise<void> {
-  await api.post("/auth/register", { email, password, role });
+export interface RegisterPayload {
+  fullName: string;
+  email: string;
+  city?: string;
+  province?: string;
+  zipCode?: string;
+  description?: string;
+  password: string;
+}
+
+export async function register(data: RegisterPayload): Promise<void> {
+  await api.post("/auth/register", data);
 }

--- a/CDNC-frontend/src/pages/FindMP.tsx
+++ b/CDNC-frontend/src/pages/FindMP.tsx
@@ -4,45 +4,39 @@ import { RunningBanner } from "@/components/Home/RunningBanner";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { toast } from "@/hooks/use-toast";
+import api from "@/lib/api";
 
 const FindMP = () => {
   const [postalCode, setPostalCode] = useState("");
   const [searchPerformed, setSearchPerformed] = useState(false);
+  interface MPContact {
+    _id: string;
+    name: string;
+    party: string;
+    constituency: string;
+    email: string;
+    phone: string;
+    image: string;
+  }
+  const [mpList, setMpList] = useState<MPContact[]>([]);
 
-  const mpList = [
-    {
-      name: "Sarah Johnson",
-      party: "Progressive Party",
-      constituency: "Central District",
-      email: "sarah.johnson@parliament.gov",
-      phone: "(555) 123-4567",
-      image: "https://images.unsplash.com/photo-1649972904349-6e44c42644a7"
-    },
-    {
-      name: "Michael Chen",
-      party: "Unity Alliance",
-      constituency: "Eastern District",
-      email: "michael.chen@parliament.gov",
-      phone: "(555) 234-5678",
-      image: "https://images.unsplash.com/photo-1488590528505-98d2b5aba04b"
-    },
-    {
-      name: "Emma Wilson",
-      party: "Democratic Coalition",
-      constituency: "Western District",
-      email: "emma.wilson@parliament.gov",
-      phone: "(555) 345-6789",
-      image: "https://images.unsplash.com/photo-1518770660439-4636190af475"
-    }
-  ];
-
-  const handleSearch = (e: React.FormEvent) => {
+  const handleSearch = async (e: React.FormEvent) => {
     e.preventDefault();
-    setSearchPerformed(true);
-    toast({
-      title: "Search Complete",
-      description: "Found representatives for your area.",
-    });
+    try {
+      const res = await api.get("/mps");
+      setMpList(res.data);
+      setSearchPerformed(true);
+      toast({
+        title: "Search Complete",
+        description: "Found representatives for your area.",
+      });
+    } catch (err) {
+      toast({
+        title: "Search Failed",
+        description: "Unable to load MP contacts.",
+        variant: "destructive",
+      });
+    }
   };
 
   const successStories = [
@@ -56,7 +50,7 @@ const FindMP = () => {
     <div className="flex flex-col min-h-screen">
       <Header />
       <main className="flex-grow pt-16">
-        <section className="bg-purple-light/30 py-16 px-8">
+        <section className="bg-purple-50 py-16 px-8">
           <div className="max-w-screen-xl mx-auto text-center">
             <h1 className="text-4xl md:text-5xl font-bold mb-6 text-purple-900">Find Your MP</h1>
             <p className="text-lg md:text-xl text-gray-600 mb-8">
@@ -70,7 +64,7 @@ const FindMP = () => {
                   value={postalCode}
                   onChange={(e) => setPostalCode(e.target.value)}
                   placeholder="Enter your postal code"
-                  className="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  className="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                   required
                 />
                 <Button type="submit" className="btn btn-secondary">
@@ -81,9 +75,9 @@ const FindMP = () => {
           </div>
         </section>
 
-        <RunningBanner 
+        <RunningBanner
           items={successStories}
-          className="bg-purple/10 text-purple-900 py-3"
+          className="bg-purple-50 text-purple-900 py-3"
           speed={20}
         />
 
@@ -94,7 +88,7 @@ const FindMP = () => {
               
               <div className="grid md:grid-cols-3 gap-8">
                 {mpList.map((mp, index) => (
-                  <div key={index} className="bg-white p-6 rounded-lg shadow-sm border border-purple/10">
+                  <div key={index} className="bg-white p-6 rounded-lg shadow-sm border border-purple-200">
                     <img
                       src={mp.image}
                       alt={mp.name}
@@ -114,10 +108,10 @@ const FindMP = () => {
                       </p>
                     </div>
                     <div className="mt-4 space-y-2">
-                      <Button variant="outline" className="w-full border-purple text-purple-900 hover:bg-purple hover:text-white">
+                      <Button variant="outline" className="w-full border-purple-600 text-purple-900 hover:bg-purple-600 hover:text-white">
                         Contact MP
                       </Button>
-                      <Button variant="outline" className="w-full border-purple text-purple-900 hover:bg-purple hover:text-white">
+                      <Button variant="outline" className="w-full border-purple-600 text-purple-900 hover:bg-purple-600 hover:text-white">
                         Schedule Meeting
                       </Button>
                     </div>

--- a/CDNC-frontend/src/pages/FindMP.tsx
+++ b/CDNC-frontend/src/pages/FindMP.tsx
@@ -10,13 +10,12 @@ const FindMP = () => {
   const [province, setProvince] = useState("");
   const [searchPerformed, setSearchPerformed] = useState(false);
   interface MPContact {
-    _id: string;
+    id: string;
     name: string;
     party: string;
     constituency: string;
-    email: string;
-    phone: string;
-    image: string;
+    province: string;
+    startDate?: string;
   }
   const [mpList, setMpList] = useState<MPContact[]>([]);
 
@@ -85,28 +84,17 @@ const FindMP = () => {
           <section className="py-16 px-8">
             <div className="max-w-screen-xl mx-auto">
               <h2 className="text-2xl font-bold mb-8 text-purple-900">Your Representatives</h2>
-              
+
               <div className="grid md:grid-cols-3 gap-8">
                 {mpList.map((mp, index) => (
                   <div key={index} className="bg-white p-6 rounded-lg shadow-sm border border-purple-200">
-                    <img
-                      src={mp.image}
-                      alt={mp.name}
-                      className="w-full h-48 object-cover rounded-lg mb-4"
-                    />
                     <h3 className="text-xl font-semibold mb-2 text-purple-900">{mp.name}</h3>
                     <p className="text-gray-600 mb-1">{mp.party}</p>
-                    <p className="text-gray-600 mb-3">{mp.constituency}</p>
-                    <div className="space-y-2">
-                      <p className="text-sm text-gray-600">
-                        <i className="ti ti-mail mr-2" />
-                        {mp.email}
-                      </p>
-                      <p className="text-sm text-gray-600">
-                        <i className="ti ti-phone mr-2" />
-                        {mp.phone}
-                      </p>
-                    </div>
+                    <p className="text-gray-600 mb-1">{mp.constituency}</p>
+                    <p className="text-gray-600 mb-3">{mp.province}</p>
+                    {mp.startDate && (
+                      <p className="text-sm text-gray-500">Serving since {mp.startDate}</p>
+                    )}
                     <div className="mt-4 space-y-2">
                       <Button variant="outline" className="w-full border-purple-600 text-purple-900 hover:bg-purple-600 hover:text-white">
                         Contact MP

--- a/CDNC-frontend/src/pages/FindMP.tsx
+++ b/CDNC-frontend/src/pages/FindMP.tsx
@@ -7,7 +7,7 @@ import { toast } from "@/hooks/use-toast";
 import api from "@/lib/api";
 
 const FindMP = () => {
-  const [postalCode, setPostalCode] = useState("");
+  const [province, setProvince] = useState("");
   const [searchPerformed, setSearchPerformed] = useState(false);
   interface MPContact {
     _id: string;
@@ -23,7 +23,7 @@ const FindMP = () => {
   const handleSearch = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await api.get("/mps");
+      const res = await api.get("/mps", { params: { province } });
       setMpList(res.data);
       setSearchPerformed(true);
       toast({
@@ -61,9 +61,9 @@ const FindMP = () => {
               <div className="flex gap-4">
                 <input
                   type="text"
-                  value={postalCode}
-                  onChange={(e) => setPostalCode(e.target.value)}
-                  placeholder="Enter your postal code"
+                  value={province}
+                  onChange={(e) => setProvince(e.target.value)}
+                  placeholder="Enter your province or territory"
                   className="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                   required
                 />

--- a/CDNC-frontend/src/pages/SignIn.tsx
+++ b/CDNC-frontend/src/pages/SignIn.tsx
@@ -74,12 +74,13 @@ const SignIn = () => {
                 Sign In
               </Button>
 
-              <p className="text-center text-sm text-gray-600 mt-4">
-                Don't have an account?{" "}
-                <Link to="/sign-up" className="text-purple-900 hover:text-purple-900 font-medium">
-                  Create one now
-                </Link>
-              </p>
+              <Button
+                asChild
+                variant="outline"
+                className="w-full mt-2"
+              >
+                <Link to="/sign-up">Create Account</Link>
+              </Button>
             </form>
           </div>
         </div>

--- a/CDNC-frontend/src/pages/SignIn.tsx
+++ b/CDNC-frontend/src/pages/SignIn.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "@/hooks/use-toast";
 import { login } from "@/lib/auth";
 import { Link } from "react-router-dom";
+import axios from "axios";
 
 const SignIn = () => {
   const [email, setEmail] = useState("");
@@ -20,13 +21,17 @@ const SignIn = () => {
       });
       setEmail("");
       setPassword("");
-    } catch (err) {
-      toast({
-        title: "Sign in failed",
-        description: "Invalid credentials",
-        variant: "destructive",
-      });
-    }
+      } catch (err) {
+        const message =
+          axios.isAxiosError(err) && err.response?.data?.error
+            ? err.response.data.error
+            : "Invalid credentials";
+        toast({
+          title: "Sign in failed",
+          description: message,
+          variant: "destructive",
+        });
+      }
   };
 
   return (

--- a/CDNC-frontend/src/pages/SignIn.tsx
+++ b/CDNC-frontend/src/pages/SignIn.tsx
@@ -67,22 +67,6 @@ const SignIn = () => {
                   />
               </div>
 
-              <div className="flex items-center justify-between">
-                <div className="flex items-center">
-                  <input
-                    id="remember"
-                    type="checkbox"
-                    className="h-4 w-4 text-purple-900 border-gray-300 rounded"
-                  />
-                  <label htmlFor="remember" className="ml-2 block text-sm text-gray-700">
-                    Remember me
-                  </label>
-                </div>
-                <a href="#" className="text-sm text-purple-900 hover:text-purple-900">
-                  Forgot password?
-                </a>
-              </div>
-
               <Button
                 type="submit"
                 className="w-full bg-purple hover:bg-purple-dark text-white"

--- a/CDNC-frontend/src/pages/SignIn.tsx
+++ b/CDNC-frontend/src/pages/SignIn.tsx
@@ -36,13 +36,13 @@ const SignIn = () => {
 
   return (
     <PageLayout>
-      <section className="bg-purple-light/30 py-16 px-8">
+      <section className="bg-purple-50 py-16 px-8">
         <div className="max-w-screen-xl mx-auto text-center">
           <h1 className="text-4xl md:text-5xl font-bold mb-6 text-purple-900">Welcome Back</h1>
           <p className="text-lg md:text-xl text-gray-600 mb-8">
             Sign in to access your caregiver resources and community
           </p>
-          <div className="max-w-md mx-auto bg-white rounded-lg shadow-sm border border-purple/10 p-8">
+          <div className="max-w-md mx-auto bg-white rounded-lg shadow-sm border border-purple-200 p-8">
             <form onSubmit={handleSubmit} className="space-y-4">
               <div>
                 <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
@@ -53,7 +53,7 @@ const SignIn = () => {
                   id="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                     required
                   />
               </div>
@@ -67,21 +67,21 @@ const SignIn = () => {
                   id="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                     required
                   />
               </div>
 
               <Button
                 type="submit"
-                className="w-full bg-purple hover:bg-purple-dark text-white"
+                className="w-full bg-purple-600 hover:bg-purple-700 text-white"
               >
                 Log In
               </Button>
 
               <p className="text-sm text-center mt-4">
                 Don't have an account?{' '}
-                <Link to="/sign-up" className="text-purple font-medium">
+                <Link to="/sign-up" className="text-purple-600 font-medium">
                   Create Account
                 </Link>
               </p>

--- a/CDNC-frontend/src/pages/SignIn.tsx
+++ b/CDNC-frontend/src/pages/SignIn.tsx
@@ -79,13 +79,12 @@ const SignIn = () => {
                 Log In
               </Button>
 
-              <Button
-                asChild
-                variant="outline"
-                className="w-full mt-2"
-              >
-                <Link to="/sign-up">Create Account</Link>
-              </Button>
+              <p className="text-sm text-center mt-4">
+                Don't have an account?{' '}
+                <Link to="/sign-up" className="text-purple font-medium">
+                  Create Account
+                </Link>
+              </p>
             </form>
           </div>
         </div>

--- a/CDNC-frontend/src/pages/SignIn.tsx
+++ b/CDNC-frontend/src/pages/SignIn.tsx
@@ -16,7 +16,7 @@ const SignIn = () => {
       const res = await login(email, password);
       localStorage.setItem("token", res.token);
       toast({
-        title: "Sign in successful",
+        title: "Login successful",
         description: `Welcome back to CDNC!`,
       });
       setEmail("");
@@ -26,11 +26,11 @@ const SignIn = () => {
           axios.isAxiosError(err) && err.response?.data?.error
             ? err.response.data.error
             : "Invalid credentials";
-        toast({
-          title: "Sign in failed",
-          description: message,
-          variant: "destructive",
-        });
+      toast({
+        title: "Login failed",
+        description: message,
+        variant: "destructive",
+      });
       }
   };
 
@@ -76,7 +76,7 @@ const SignIn = () => {
                 type="submit"
                 className="w-full bg-purple hover:bg-purple-dark text-white"
               >
-                Sign In
+                Log In
               </Button>
 
               <Button

--- a/CDNC-frontend/src/pages/SignUp.tsx
+++ b/CDNC-frontend/src/pages/SignUp.tsx
@@ -44,13 +44,13 @@ const SignUp = () => {
 
   return (
     <PageLayout>
-      <section className="bg-purple-light/30 py-16 px-8">
-        <div className="max-w-screen-xl mx-auto text-center">
-          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-purple-900">Create Account</h1>
-          <p className="text-lg md:text-xl text-gray-600 mb-8">
-            Join CDNC to access resources and community
-          </p>
-          <div className="max-w-md mx-auto bg-white rounded-lg shadow-sm border border-purple/10 p-8">
+      <section className="bg-purple-50 py-16 px-8">
+          <div className="max-w-screen-xl mx-auto text-center">
+            <h1 className="text-4xl md:text-5xl font-bold mb-6 text-purple-900">Create Account</h1>
+            <p className="text-lg md:text-xl text-gray-600 mb-8">
+              Join CDNC to access resources and community
+            </p>
+            <div className="max-w-md mx-auto bg-white rounded-lg shadow-sm border border-purple-200 p-8">
             <form onSubmit={handleSubmit} className="space-y-4">
               <div>
                 <label htmlFor="fullName" className="block text-sm font-medium text-gray-700 mb-1">
@@ -61,7 +61,7 @@ const SignUp = () => {
                   id="fullName"
                   value={fullName}
                   onChange={(e) => setFullName(e.target.value)}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                   required
                 />
               </div>
@@ -75,7 +75,7 @@ const SignUp = () => {
                   id="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                   required
                 />
               </div>
@@ -90,7 +90,7 @@ const SignUp = () => {
                     id="city"
                     value={city}
                     onChange={(e) => setCity(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                   />
                 </div>
                 <div>
@@ -102,7 +102,7 @@ const SignUp = () => {
                     id="province"
                     value={province}
                     onChange={(e) => setProvince(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                   />
                 </div>
               </div>
@@ -117,7 +117,7 @@ const SignUp = () => {
                     id="zipCode"
                     value={zipCode}
                     onChange={(e) => setZipCode(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                   />
                 </div>
                 <div>
@@ -129,7 +129,7 @@ const SignUp = () => {
                     id="description"
                     value={description}
                     onChange={(e) => setDescription(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                   />
                 </div>
               </div>
@@ -143,21 +143,21 @@ const SignUp = () => {
                   id="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
                   required
                 />
               </div>
 
               <Button
                 type="submit"
-                className="w-full bg-purple hover:bg-purple-dark text-white"
+                className="w-full bg-purple-600 hover:bg-purple-700 text-white"
               >
                 Create Account
               </Button>
 
               <p className="text-sm text-center mt-4">
                 Already have an account?{' '}
-                <Link to="/sign-in" className="text-purple font-medium">
+                <Link to="/sign-in" className="text-purple-600 font-medium">
                   Log In
                 </Link>
               </p>

--- a/CDNC-frontend/src/pages/SignUp.tsx
+++ b/CDNC-frontend/src/pages/SignUp.tsx
@@ -2,28 +2,27 @@ import { PageLayout } from "@/components/Layout/PageLayout";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { toast } from "@/hooks/use-toast";
-import { login } from "@/lib/auth";
-import { Link } from "react-router-dom";
+import { register } from "@/lib/auth";
+import { useNavigate } from "react-router-dom";
 
-const SignIn = () => {
+const SignUp = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [role, setRole] = useState("Player");
+  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await login(email, password);
-      localStorage.setItem("token", res.token);
-      toast({
-        title: "Sign in successful",
-        description: `Welcome back to CDNC!`,
-      });
+      await register(email, password, role);
+      toast({ title: "Account created", description: "You can now sign in." });
       setEmail("");
       setPassword("");
+      navigate("/sign-in");
     } catch (err) {
       toast({
-        title: "Sign in failed",
-        description: "Invalid credentials",
+        title: "Sign up failed",
+        description: "Unable to create account",
         variant: "destructive",
       });
     }
@@ -33,9 +32,9 @@ const SignIn = () => {
     <PageLayout>
       <section className="bg-purple-light/30 py-16 px-8">
         <div className="max-w-screen-xl mx-auto text-center">
-          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-purple-900">Welcome Back</h1>
+          <h1 className="text-4xl md:text-5xl font-bold mb-6 text-purple-900">Create Account</h1>
           <p className="text-lg md:text-xl text-gray-600 mb-8">
-            Sign in to access your caregiver resources and community
+            Join CDNC to access resources and community
           </p>
           <div className="max-w-md mx-auto bg-white rounded-lg shadow-sm border border-purple/10 p-8">
             <form onSubmit={handleSubmit} className="space-y-4">
@@ -67,35 +66,24 @@ const SignIn = () => {
                   />
               </div>
 
-              <div className="flex items-center justify-between">
-                <div className="flex items-center">
-                  <input
-                    id="remember"
-                    type="checkbox"
-                    className="h-4 w-4 text-purple-900 border-gray-300 rounded"
-                  />
-                  <label htmlFor="remember" className="ml-2 block text-sm text-gray-700">
-                    Remember me
-                  </label>
-                </div>
-                <a href="#" className="text-sm text-purple-900 hover:text-purple-900">
-                  Forgot password?
-                </a>
+              <div>
+                <label htmlFor="role" className="block text-sm font-medium text-gray-700 mb-1">
+                  Role
+                </label>
+                <select
+                  id="role"
+                  value={role}
+                  onChange={(e) => setRole(e.target.value)}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                >
+                  <option value="Player">Player</option>
+                  <option value="Host">Host</option>
+                </select>
               </div>
 
-              <Button
-                type="submit"
-                className="w-full bg-purple hover:bg-purple-dark text-white"
-              >
-                Sign In
+              <Button type="submit" className="w-full bg-purple hover:bg-purple-dark text-white">
+                Sign Up
               </Button>
-
-              <p className="text-center text-sm text-gray-600 mt-4">
-                Don't have an account?{" "}
-                <Link to="/sign-up" className="text-purple-900 hover:text-purple-900 font-medium">
-                  Create one now
-                </Link>
-              </p>
             </form>
           </div>
         </div>
@@ -104,4 +92,4 @@ const SignIn = () => {
   );
 };
 
-export default SignIn;
+export default SignUp;

--- a/CDNC-frontend/src/pages/SignUp.tsx
+++ b/CDNC-frontend/src/pages/SignUp.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "@/hooks/use-toast";
 import { register } from "@/lib/auth";
 import { Link, useNavigate } from "react-router-dom";
+import axios from "axios";
 
 const SignUp = () => {
   const [fullName, setFullName] = useState("");
@@ -28,13 +29,17 @@ const SignUp = () => {
       setDescription("");
       setPassword("");
       navigate("/sign-in");
-    } catch (err) {
-      toast({
-        title: "Sign up failed",
-        description: "Unable to create account",
-        variant: "destructive",
-      });
-    }
+      } catch (err) {
+        const message =
+          axios.isAxiosError(err) && err.response?.data?.error
+            ? err.response.data.error
+            : "Unable to create account";
+        toast({
+          title: "Sign up failed",
+          description: message,
+          variant: "destructive",
+        });
+      }
   };
 
   return (

--- a/CDNC-frontend/src/pages/SignUp.tsx
+++ b/CDNC-frontend/src/pages/SignUp.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { toast } from "@/hooks/use-toast";
 import { register } from "@/lib/auth";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 const SignUp = () => {
   const [fullName, setFullName] = useState("");
@@ -145,6 +145,10 @@ const SignUp = () => {
 
               <Button type="submit" className="w-full bg-purple hover:bg-purple-dark text-white">
                 Sign Up
+              </Button>
+
+              <Button asChild variant="outline" className="w-full mt-2">
+                <Link to="/sign-in">Log In</Link>
               </Button>
             </form>
           </div>

--- a/CDNC-frontend/src/pages/SignUp.tsx
+++ b/CDNC-frontend/src/pages/SignUp.tsx
@@ -6,17 +6,26 @@ import { register } from "@/lib/auth";
 import { useNavigate } from "react-router-dom";
 
 const SignUp = () => {
+  const [fullName, setFullName] = useState("");
   const [email, setEmail] = useState("");
+  const [city, setCity] = useState("");
+  const [province, setProvince] = useState("");
+  const [zipCode, setZipCode] = useState("");
+  const [description, setDescription] = useState("");
   const [password, setPassword] = useState("");
-  const [role, setRole] = useState("Player");
   const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await register(email, password, role);
+      await register({ fullName, email, city, province, zipCode, description, password });
       toast({ title: "Account created", description: "You can now sign in." });
+      setFullName("");
       setEmail("");
+      setCity("");
+      setProvince("");
+      setZipCode("");
+      setDescription("");
       setPassword("");
       navigate("/sign-in");
     } catch (err) {
@@ -39,6 +48,20 @@ const SignUp = () => {
           <div className="max-w-md mx-auto bg-white rounded-lg shadow-sm border border-purple/10 p-8">
             <form onSubmit={handleSubmit} className="space-y-4">
               <div>
+                <label htmlFor="fullName" className="block text-sm font-medium text-gray-700 mb-1">
+                  Full Name
+                </label>
+                <input
+                  type="text"
+                  id="fullName"
+                  value={fullName}
+                  onChange={(e) => setFullName(e.target.value)}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  required
+                />
+              </div>
+
+              <div>
                 <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
                   Email Address
                 </label>
@@ -47,9 +70,63 @@ const SignUp = () => {
                   id="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  required
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label htmlFor="city" className="block text-sm font-medium text-gray-700 mb-1">
+                    City
+                  </label>
+                  <input
+                    type="text"
+                    id="city"
+                    value={city}
+                    onChange={(e) => setCity(e.target.value)}
                     className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
-                    required
                   />
+                </div>
+                <div>
+                  <label htmlFor="province" className="block text-sm font-medium text-gray-700 mb-1">
+                    Province
+                  </label>
+                  <input
+                    type="text"
+                    id="province"
+                    value={province}
+                    onChange={(e) => setProvince(e.target.value)}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label htmlFor="zipCode" className="block text-sm font-medium text-gray-700 mb-1">
+                    Zip Code
+                  </label>
+                  <input
+                    type="text"
+                    id="zipCode"
+                    value={zipCode}
+                    onChange={(e) => setZipCode(e.target.value)}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-1">
+                    Description
+                  </label>
+                  <input
+                    type="text"
+                    id="description"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  />
+                </div>
               </div>
 
               <div>
@@ -61,24 +138,9 @@ const SignUp = () => {
                   id="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
-                    required
-                  />
-              </div>
-
-              <div>
-                <label htmlFor="role" className="block text-sm font-medium text-gray-700 mb-1">
-                  Role
-                </label>
-                <select
-                  id="role"
-                  value={role}
-                  onChange={(e) => setRole(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
-                >
-                  <option value="Player">Player</option>
-                  <option value="Host">Host</option>
-                </select>
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                  required
+                />
               </div>
 
               <Button type="submit" className="w-full bg-purple hover:bg-purple-dark text-white">

--- a/CDNC-frontend/src/pages/SignUp.tsx
+++ b/CDNC-frontend/src/pages/SignUp.tsx
@@ -20,7 +20,7 @@ const SignUp = () => {
     e.preventDefault();
     try {
       await register({ fullName, email, city, province, zipCode, description, password });
-      toast({ title: "Account created", description: "You can now sign in." });
+      toast({ title: "Account created", description: "You can now log in." });
       setFullName("");
       setEmail("");
       setCity("");
@@ -35,7 +35,7 @@ const SignUp = () => {
             ? err.response.data.error
             : "Unable to create account";
         toast({
-          title: "Sign up failed",
+          title: "Account creation failed",
           description: message,
           variant: "destructive",
         });
@@ -149,7 +149,7 @@ const SignUp = () => {
               </div>
 
               <Button type="submit" className="w-full bg-purple hover:bg-purple-dark text-white">
-                Sign Up
+                Create Account
               </Button>
 
               <Button asChild variant="outline" className="w-full mt-2">

--- a/CDNC-frontend/src/pages/SignUp.tsx
+++ b/CDNC-frontend/src/pages/SignUp.tsx
@@ -148,13 +148,19 @@ const SignUp = () => {
                 />
               </div>
 
-              <Button type="submit" className="w-full bg-purple hover:bg-purple-dark text-white">
+              <Button
+                type="submit"
+                className="w-full bg-purple hover:bg-purple-dark text-white"
+              >
                 Create Account
               </Button>
 
-              <Button asChild variant="outline" className="w-full mt-2">
-                <Link to="/sign-in">Log In</Link>
-              </Button>
+              <p className="text-sm text-center mt-4">
+                Already have an account?{' '}
+                <Link to="/sign-in" className="text-purple font-medium">
+                  Log In
+                </Link>
+              </p>
             </form>
           </div>
         </div>

--- a/CDNC-frontend/tailwind.config.ts
+++ b/CDNC-frontend/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -98,5 +99,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;

--- a/CDNC-frontend/vite.config.ts
+++ b/CDNC-frontend/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
-import path from "path";
+import tsconfigPaths from "vite-tsconfig-paths";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
@@ -10,13 +10,8 @@ export default defineConfig(({ mode }) => ({
     port: 8080,
   },
   plugins: [
+    tsconfigPaths(),
     react(),
-    mode === 'development' &&
-    componentTagger(),
+    mode === 'development' && componentTagger(),
   ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-  },
 }));


### PR DESCRIPTION
## Summary
- switch user model and auth logic to email-based fields
- expose auth helpers and API client for frontend
- add sign-in and sign-up pages wired to backend and sample `.env`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype @typescript-eslint/no-empty-object-type)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a031a0d0833198457789007421af