### PR TITLE
Show user initials with sign out dropdown

### DIFF
--- a/Backend/controller/auth.controller.js
+++ b/Backend/controller/auth.controller.js
@@ -53,7 +53,7 @@ const { generateToken } = require('../utils/jwt');
       }
 
       const token = generateToken(user);
-      return res.status(200).json({ token, email: user.email });
+      return res.status(200).json({ token, email: user.email, fullName: user.fullName });
     } catch (err) {
       console.error('❌ Login error:', err);
       return res.status(500).json({ error: 'Server error during login' });

--- a/CDNC-frontend/src/components/Layout/Header.tsx
+++ b/CDNC-frontend/src/components/Layout/Header.tsx
@@ -1,20 +1,35 @@
 import { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { FaBars, FaTimes, FaHeartbeat } from "react-icons/fa";
 
 export const Header = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [userInitial, setUserInitial] = useState<string | null>(null);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const handleScroll = () => {
       setIsScrolled(window.scrollY > 50);
     };
 
+    const name = localStorage.getItem("fullName");
+    if (name) {
+      setUserInitial(name.charAt(0).toUpperCase());
+    }
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
+
+  const handleSignOut = () => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("fullName");
+    setUserInitial(null);
+    setIsDropdownOpen(false);
+    navigate("/");
+  };
 
   return (
     <header className="fixed top-0 inset-x-0 z-50 bg-white shadow-md">
@@ -57,12 +72,33 @@ export const Header = () => {
           </Link>
         </nav>
 
-        <Link
-          to="/sign-in"
-          className="bg-purple-600 text-white text-base font-semibold px-4 py-2 rounded-lg hover:bg-purple-900 transition-colors"
-        >
-          Sign In
-        </Link>
+        {userInitial ? (
+          <div className="relative">
+            <button
+              onClick={() => setIsDropdownOpen((prev) => !prev)}
+              className="bg-purple-600 text-white text-base font-semibold w-10 h-10 rounded-full hover:bg-purple-900 transition-colors flex items-center justify-center"
+            >
+              {userInitial}
+            </button>
+            {isDropdownOpen && (
+              <div className="absolute right-0 mt-2 w-32 bg-white border rounded-md shadow-lg">
+                <button
+                  onClick={handleSignOut}
+                  className="block w-full text-left px-4 py-2 text-gray-700 hover:bg-gray-100"
+                >
+                  Sign Out
+                </button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <Link
+            to="/sign-in"
+            className="bg-purple-600 text-white text-base font-semibold px-4 py-2 rounded-lg hover:bg-purple-900 transition-colors"
+          >
+            Sign In
+          </Link>
+        )}
       </div>
     </header>
   );

--- a/CDNC-frontend/src/lib/auth.ts
+++ b/CDNC-frontend/src/lib/auth.ts
@@ -3,6 +3,7 @@ import api from "./api";
 export interface AuthResponse {
   token: string;
   email: string;
+  fullName: string;
 }
 
 export async function login(email: string, password: string): Promise<AuthResponse> {

--- a/CDNC-frontend/src/pages/SignIn.tsx
+++ b/CDNC-frontend/src/pages/SignIn.tsx
@@ -3,24 +3,27 @@ import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { toast } from "@/hooks/use-toast";
 import { login } from "@/lib/auth";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import axios from "axios";
 
 const SignIn = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
       const res = await login(email, password);
       localStorage.setItem("token", res.token);
+      localStorage.setItem("fullName", res.fullName);
       toast({
         title: "Login successful",
         description: `Welcome back to CDNC!`,
       });
       setEmail("");
       setPassword("");
+      navigate("/");
       } catch (err) {
         const message =
           axios.isAxiosError(err) && err.response?.data?.error


### PR DESCRIPTION
## Summary
- Return user's full name during login and store it client-side
- Display user initial in header with sign-out dropdown after login
- Redirect to home on sign-in

## Testing
- `npm run lint`
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c1a4d17e0c833183244718bcc486dc