### PR TITLE
Add community enrollment API and integrate frontend form

### DIFF
--- a/Backend/Data/Member.js
+++ b/Backend/Data/Member.js
@@ -1,0 +1,33 @@
+const mongoose = require("mongoose");
+
+const memberSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    email: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+      unique: true,
+      match: [/.+@.+\..+/, "Please enter a valid email address"],
+    },
+    role: {
+      type: String,
+      required: true,
+      enum: ["family", "professional", "volunteer", "seeking", "other"],
+    },
+    termsAcceptedAt: {
+      type: Date,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+module.exports = mongoose.model("Member", memberSchema);

--- a/Backend/controller/member.controller.js
+++ b/Backend/controller/member.controller.js
@@ -1,0 +1,72 @@
+const Member = require("../Data/Member");
+const { sendMemberConfirmationEmail, trackMemberEnrollment } = require("../utils/notifications");
+
+const allowedRoles = new Set(["family", "professional", "volunteer", "seeking", "other"]);
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const create = async (req, res) => {
+  try {
+    const { name, email, role, agreeToTerms } = req.body;
+    const errors = {};
+
+    const trimmedName = typeof name === "string" ? name.trim().replace(/\s+/g, " ") : "";
+    if (!trimmedName) {
+      errors.name = "Your name is required.";
+    }
+
+    const normalizedEmail = typeof email === "string" ? email.trim().toLowerCase() : "";
+    if (!normalizedEmail) {
+      errors.email = "An email address is required.";
+    } else if (!emailRegex.test(normalizedEmail)) {
+      errors.email = "Enter a valid email address.";
+    }
+
+    if (!role || !allowedRoles.has(role)) {
+      errors.role = "Select the option that best describes you.";
+    }
+
+    if (!agreeToTerms) {
+      errors.agreeToTerms = "You must agree to the terms to join.";
+    }
+
+    if (Object.keys(errors).length > 0) {
+      return res.status(400).json({ error: "Validation failed", errors });
+    }
+
+    const existingMember = await Member.findOne({ email: normalizedEmail });
+    if (existingMember) {
+      return res.status(409).json({ error: "This email is already enrolled." });
+    }
+
+    const member = await Member.create({
+      name: trimmedName,
+      email: normalizedEmail,
+      role,
+      termsAcceptedAt: new Date(),
+    });
+
+    try {
+      await sendMemberConfirmationEmail(member);
+    } catch (err) {
+      console.error("❌ Failed to send confirmation email:", err);
+    }
+
+    try {
+      await trackMemberEnrollment(member);
+    } catch (err) {
+      console.error("❌ Failed to log analytics event:", err);
+    }
+
+    return res.status(201).json({
+      message: "Enrollment successful",
+      memberId: member._id,
+    });
+  } catch (err) {
+    console.error("❌ Member enrollment error:", err);
+    return res
+      .status(503)
+      .json({ error: "Something went wrong while enrolling. Please try again later." });
+  }
+};
+
+module.exports = { create };

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.18.1"
+        "mongoose": "^8.18.1",
+        "nodemailer": "^6.9.16"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -789,6 +790,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.18.1"
+    "mongoose": "^8.18.1",
+    "nodemailer": "^6.9.16"
   }
 }

--- a/Backend/routes/member.routes.js
+++ b/Backend/routes/member.routes.js
@@ -1,0 +1,6 @@
+const router = require("express").Router();
+const { create } = require("../controller/member.controller");
+
+router.post("/", create);
+
+module.exports = router;

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -8,7 +8,9 @@ dotenv.config();
 
 const authRoutes = require("./routes/auth.routes");
 const mpRoutes = require("./routes/mp.routes");
+const memberRoutes = require("./routes/member.routes");
 const User = require("./Data/User");
+const Member = require("./Data/Member");
 
 // App + Server
 const app = express();
@@ -22,6 +24,7 @@ app.use(express.json());
 // Routes
 app.use("/api/auth", authRoutes);
 app.use("/api/mps", mpRoutes);
+app.use("/api/members", memberRoutes);
 
 // MongoDB
 mongoose
@@ -29,7 +32,7 @@ mongoose
   .then(async () => {
     console.log("✅ MongoDB connected");
     // Ensure obsolete indexes (e.g., legacy username) are removed
-    await User.syncIndexes();
+    await Promise.all([User.syncIndexes(), Member.syncIndexes()]);
 
     const PORT = process.env.PORT || 5001;
     server.listen(PORT, () => {

--- a/Backend/utils/notifications.js
+++ b/Backend/utils/notifications.js
@@ -1,0 +1,75 @@
+const nodemailer = require("nodemailer");
+
+const buildTransporter = () => {
+  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS } = process.env;
+
+  if (!SMTP_HOST || !SMTP_PORT || !SMTP_USER || !SMTP_PASS) {
+    return null;
+  }
+
+  return nodemailer.createTransport({
+    host: SMTP_HOST,
+    port: Number(SMTP_PORT),
+    secure: Number(SMTP_PORT) === 465,
+    auth: {
+      user: SMTP_USER,
+      pass: SMTP_PASS,
+    },
+  });
+};
+
+const sendMemberConfirmationEmail = async (member) => {
+  const transporter = buildTransporter();
+
+  if (!transporter) {
+    console.info(
+      `📬 Confirmation email skipped for ${member.email} (SMTP not configured).`
+    );
+    return;
+  }
+
+  const from = process.env.EMAIL_FROM || process.env.SMTP_USER;
+  const subject = "Welcome to the Childhood Disability Network Canada";
+  const text = `Hi ${member.name},\n\nThank you for joining our caregiver community. We're excited to have you with us!\n\n- The CDNC Team`;
+  const html = `<p>Hi ${member.name},</p><p>Thank you for joining our caregiver community. We're excited to have you with us!</p><p>- The CDNC Team</p>`;
+
+  await transporter.sendMail({
+    to: member.email,
+    from,
+    subject,
+    text,
+    html,
+  });
+
+  console.info(`📬 Confirmation email sent to ${member.email}`);
+};
+
+const trackMemberEnrollment = async (member) => {
+  const webhookUrl = process.env.ANALYTICS_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    console.info(`📈 Member enrolled: ${member.email} (${member.role})`);
+    return;
+  }
+
+  await fetch(webhookUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      event: "member_enrolled",
+      memberId: member._id,
+      email: member.email,
+      role: member.role,
+      timestamp: new Date().toISOString(),
+    }),
+  });
+
+  console.info(`📈 Enrollment event sent for ${member.email}`);
+};
+
+module.exports = {
+  sendMemberConfirmationEmail,
+  trackMemberEnrollment,
+};

--- a/CDNC-frontend/src/lib/members.ts
+++ b/CDNC-frontend/src/lib/members.ts
@@ -1,0 +1,20 @@
+import api from "./api";
+
+export interface CreateMemberPayload {
+  name: string;
+  email: string;
+  role: string;
+  agreeToTerms: boolean;
+}
+
+export interface CreateMemberResponse {
+  message: string;
+  memberId: string;
+}
+
+export async function createMember(
+  data: CreateMemberPayload
+): Promise<CreateMemberResponse> {
+  const res = await api.post<CreateMemberResponse>("/members", data);
+  return res.data;
+}

--- a/CDNC-frontend/src/pages/JoinCommunity.tsx
+++ b/CDNC-frontend/src/pages/JoinCommunity.tsx
@@ -3,12 +3,17 @@ import { Footer } from "@/components/Layout/Footer";
 import { RunningBanner } from "@/components/Support/RunningBanner";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
+import axios from "axios";
 import { toast } from "@/hooks/use-toast";
+import { createMember } from "@/lib/members";
 
 const JoinCommunity = () => {
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
+  const [agreeToTerms, setAgreeToTerms] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
   
   const testimonials = [
     "Joining this community was the best decision I made as a caregiver. The support is incredible. - Maria T.",
@@ -17,15 +22,92 @@ const JoinCommunity = () => {
     "Finally found people who understand what I'm going through. - Robert J."
   ];
   
-  const handleSubmit = (e: React.FormEvent) => {
+  const validate = () => {
+    const nextErrors: Record<string, string> = {};
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      nextErrors.name = "Please tell us your name.";
+    }
+
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      nextErrors.email = "Email is required.";
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+      nextErrors.email = "Enter a valid email address.";
+    }
+
+    if (!role) {
+      nextErrors.role = "Choose the option that best describes you.";
+    }
+
+    if (!agreeToTerms) {
+      nextErrors.agreeToTerms = "Please agree to the terms to continue.";
+    }
+
+    return nextErrors;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    toast({
-      title: "Application Submitted",
-      description: "Thank you for joining our community. We'll be in touch soon!",
-    });
-    setEmail("");
-    setName("");
-    setRole("");
+    const validationErrors = validate();
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
+      await createMember({
+        name: name.trim(),
+        email: email.trim(),
+        role,
+        agreeToTerms,
+      });
+
+      toast({
+        title: "You're in!",
+        description: "Thank you for joining our community. Check your inbox for confirmation.",
+      });
+
+      setEmail("");
+      setName("");
+      setRole("");
+      setAgreeToTerms(false);
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status;
+        const data = err.response?.data as { error?: string; errors?: Record<string, string> } | undefined;
+
+        if (status === 400 && data?.errors) {
+          setErrors(data.errors);
+        } else if (status === 409) {
+          const duplicateMessage = data?.error || "This email is already enrolled.";
+          setErrors({ email: duplicateMessage });
+          toast({
+            title: "Already enrolled",
+            description: duplicateMessage,
+            variant: "destructive",
+          });
+        } else {
+          toast({
+            title: "Enrollment unavailable",
+            description: data?.error || "Something went wrong, please try again later.",
+            variant: "destructive",
+          });
+        }
+      } else {
+        toast({
+          title: "Enrollment unavailable",
+          description: "Something went wrong, please try again later.",
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
   };
   
   return (
@@ -102,7 +184,7 @@ const JoinCommunity = () => {
                 Fill out this form to join our community. Membership is free and gives you access to all our resources.
               </p>
               
-              <form onSubmit={handleSubmit} className="space-y-4">
+              <form onSubmit={handleSubmit} className="space-y-4" noValidate>
                 <div>
                   <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
                     Full Name
@@ -112,9 +194,18 @@ const JoinCommunity = () => {
                     id="name"
                     value={name}
                     onChange={(e) => setName(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                    className={`w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                      errors.name ? "border-red-500 focus:ring-red-500" : "border-gray-300 focus:ring-purple"
+                    }`}
+                    aria-invalid={Boolean(errors.name)}
+                    aria-describedby={errors.name ? "name-error" : undefined}
                     required
                   />
+                  {errors.name && (
+                    <p id="name-error" className="mt-1 text-sm text-red-600">
+                      {errors.name}
+                    </p>
+                  )}
                 </div>
                 
                 <div>
@@ -126,9 +217,18 @@ const JoinCommunity = () => {
                     id="email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                    className={`w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                      errors.email ? "border-red-500 focus:ring-red-500" : "border-gray-300 focus:ring-purple"
+                    }`}
+                    aria-invalid={Boolean(errors.email)}
+                    aria-describedby={errors.email ? "email-error" : undefined}
                     required
                   />
+                  {errors.email && (
+                    <p id="email-error" className="mt-1 text-sm text-red-600">
+                      {errors.email}
+                    </p>
+                  )}
                 </div>
                 
                 <div>
@@ -139,7 +239,11 @@ const JoinCommunity = () => {
                     id="role"
                     value={role}
                     onChange={(e) => setRole(e.target.value)}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple"
+                    className={`w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                      errors.role ? "border-red-500 focus:ring-red-500" : "border-gray-300 focus:ring-purple"
+                    }`}
+                    aria-invalid={Boolean(errors.role)}
+                    aria-describedby={errors.role ? "role-error" : undefined}
                     required
                   >
                     <option value="">Select your role</option>
@@ -149,20 +253,48 @@ const JoinCommunity = () => {
                     <option value="seeking">Seeking Caregiving Resources</option>
                     <option value="other">Other</option>
                   </select>
+                  {errors.role && (
+                    <p id="role-error" className="mt-1 text-sm text-red-600">
+                      {errors.role}
+                    </p>
+                  )}
                 </div>
                 
+                <div className="flex items-start gap-3">
+                  <input
+                    id="agreeToTerms"
+                    type="checkbox"
+                    checked={agreeToTerms}
+                    onChange={(e) => setAgreeToTerms(e.target.checked)}
+                    className="mt-1 h-4 w-4 rounded border-gray-300 text-purple-600 focus:ring-purple"
+                    aria-invalid={Boolean(errors.agreeToTerms)}
+                    aria-describedby={errors.agreeToTerms ? "terms-error" : undefined}
+                    required
+                  />
+                  <label htmlFor="agreeToTerms" className="text-sm text-gray-700">
+                    I agree to the Terms of Service and Privacy Policy.
+                  </label>
+                </div>
+                {errors.agreeToTerms && (
+                  <p id="terms-error" className="-mt-2 text-sm text-red-600">
+                    {errors.agreeToTerms}
+                  </p>
+                )}
+
                 <div className="pt-2">
                   <Button
                     type="submit"
                     className="w-full bg-purple hover:bg-purple-dark text-white"
+                    disabled={isSubmitting}
+                    aria-busy={isSubmitting}
                   >
-                    Join Community
+                    {isSubmitting ? "Submitting..." : "Join Community"}
                   </Button>
                 </div>
                 
-                <p className="text-xs text-gray-500 mt-4">
-                  By joining, you agree to our Terms of Service and Privacy Policy. We'll send you occasional updates about the community.
-                </p>
+                  <p className="text-xs text-gray-500 mt-4">
+                    We'll send you occasional updates about the community. You can opt out at any time.
+                  </p>
               </form>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add a MongoDB-backed member model, controller, and routes to handle community enrollment with confirmation email and analytics hooks
- register the new endpoint on the server and add a notification utility that sends email when SMTP is configured
- connect the Join Community form to the backend with validation, duplicate handling, terms acceptance, and toast messaging via a reusable API helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c87a2e71d08331893e16f791653378